### PR TITLE
Better error message for unknown type.

### DIFF
--- a/lib/stark/ruby.rb
+++ b/lib/stark/ruby.rb
@@ -73,7 +73,7 @@ module Stark
       elsif desc = @enums[t]
         "Stark::Converters::Enum.new(Enum_#{t})"
       else
-        raise "Blah"
+        raise "Unknown type <#{t}>"
       end
     end
 

--- a/test/test_ruby.rb
+++ b/test/test_ruby.rb
@@ -45,4 +45,23 @@ enum Status {
     ns = create_ns_module 'Blah.Blerg', 'c'
     assert ns::Enum_Status
   end
+
+  def test_forward_declaration
+    ast = Stark::Parser.ast <<-EOM
+struct Foo {
+  1: Bar bar
+}
+
+struct Bar {
+  1: i32 ids
+}
+  EOM
+
+    stream = StringIO.new
+    ruby = Stark::Ruby.new stream
+    e = assert_raise RuntimeError do
+      ruby.run ast
+    end
+    assert_equal 'Unknown type <Bar>', e.message
+  end
 end


### PR DESCRIPTION
I ran across this attempting to do a forward declaration, which isn't
allowed: "Due to inherent complexities and potential for circular
dependencies, we explicitly disallow forward declaration." [White Paper]
