### PR TITLE
Better path searching for included files.

### DIFF
--- a/lib/stark.rb
+++ b/lib/stark.rb
@@ -28,7 +28,7 @@ module Stark
     require 'stringio'
 
     begin
-      contents = file.respond_to?(:read) ? file.read : File.read(file)
+      contents = Stark::Parser.read_file(file)
       ast = Stark::Parser.ast contents
     rescue => e
       raise e, e.message + " while processing #{file} -\n#{e.backtrace.join("\n")}"

--- a/lib/stark/parser.rb
+++ b/lib/stark/parser.rb
@@ -1,6 +1,7 @@
 module Stark
 end
 
+require 'set'
 require 'stark/raw_parser'
 
 class Stark::Parser
@@ -9,11 +10,11 @@ class Stark::Parser
 
     ast.each do |elem|
       case elem
-      when AST::Include
-        data = File.read elem.path
-        out += expand(Stark::Parser.ast(data))
-      else
-        out << elem
+        when AST::Include
+          data = Stark::Parser.read_file(elem.path)
+          out += expand(Stark::Parser.ast(data))
+        else
+          out << elem
       end
     end
 
@@ -28,5 +29,17 @@ class Stark::Parser
   def self.ast(arg)
     parser = Stark::Parser.new arg
     parser.ast
+  end
+
+  def self.read_file(file)
+    @@include_path ||= Set.new([Dir.pwd])
+    if file.respond_to?(:read)
+      @@include_path << File.dirname(File.expand_path(file.path, Dir.pwd)) if file.respond_to?(:path)
+      return file.read
+    else
+      @@include_path << File.dirname(File.expand_path(file, Dir.pwd))
+      fn = (@@include_path.map { |path| File.expand_path(file, path) }.detect { |fn| File.exist?(fn) }) || file
+      File.read fn
+    end
   end
 end

--- a/test/include_blah.thrift
+++ b/test/include_blah.thrift
@@ -1,1 +1,1 @@
-include "test/blah.thrift"
+include "blah.thrift"

--- a/test/test_stark.rb
+++ b/test/test_stark.rb
@@ -64,4 +64,12 @@ class TestStark < Test::Unit::TestCase
     assert @m.const_defined?(:Types)
   end
 
+  def test_include_in_same_dir_not_working_dir
+    Dir.chdir(File.dirname(__FILE__) + '/../') do
+      file_path = File.join(File.dirname(__FILE__), 'include_blah.thrift')
+      assert_nothing_raised do
+        Stark.materialize file_path, @m
+      end
+    end
+  end
 end


### PR DESCRIPTION
Thrift will find included files in the same directory as the original
.thrift file even when executed from a different working directory.

(not sure about the whole @@include_path implementation and
what not -- seems should be an easier way)
