### PR TITLE
to_hash fix for Array of non-structs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
-scratch
+.bundle
+bin/
 pkg/
+scratch

--- a/lib/stark/struct.rb
+++ b/lib/stark/struct.rb
@@ -29,7 +29,7 @@ module Stark
           v = send name
           case v
           when Array
-            hash[name] = v.map(&:to_hash)
+            hash[name] = v.map { |o| o.respond_to?(:to_hash) ? o.to_hash : o  }
           when Struct
             hash[name] = v.to_hash
           else

--- a/test/test_ruby.rb
+++ b/test/test_ruby.rb
@@ -164,6 +164,21 @@ EOM
     assert_equal({:str => "hi", :int => 20, :bars => [{:blah => "baz"}], :q => {:int => 42}}, foo.to_hash)
   end
 
+  def test_to_hash_of_array_of_non_struct
+    ruby = create_ruby <<-EOM, :only_ast => true
+struct Foo {
+  1:list<i32> ints
+}
+EOM
+
+    ns = Module.new
+    ns.module_eval ruby
+    assert ns::Foo
+
+    foo = ns::Foo.new :ints => [1, 2]
+    assert_equal({:ints => [1, 2]}, foo.to_hash)
+  end
+
   def test_to_struct_aref
     ruby = create_ruby <<-EOM, :only_ast => true
 struct Foo {


### PR DESCRIPTION
If the struct has an Array of ints or somesuch, then there's no to_hash
method to be called on them. Seems that method in there could maybe be
shored up with just something around respond_to?
