### PR TITLE
more conservative Struct#to_hash

### DIFF
--- a/lib/stark/struct.rb
+++ b/lib/stark/struct.rb
@@ -29,7 +29,7 @@ module Stark
           v = send name
           case v
           when Array
-            hash[name] = v.map(&:to_hash)
+            hash[name] = v.map {|e| e.respond_to?(:to_hash) ? e.to_hash : e}
           when Struct
             hash[name] = v.to_hash
           else

--- a/test/test_ruby.rb
+++ b/test/test_ruby.rb
@@ -145,6 +145,7 @@ struct Bar {
 }
 struct Quux {
 1: i32 int
+2: list<string> words
 }
 struct Foo {
 1:string str
@@ -160,8 +161,8 @@ EOM
 
     foo = ns::Foo.new :str => "hi", :int => 20
     foo.bars = [ns::Bar.new(:blah => "baz")]
-    foo.q = ns::Quux.new(:int => 42)
-    assert_equal({:str => "hi", :int => 20, :bars => [{:blah => "baz"}], :q => {:int => 42}}, foo.to_hash)
+    foo.q = ns::Quux.new(:int => 42, :words => %w[a an the])
+    assert_equal({:str => "hi", :int => 20, :bars => [{:blah => "baz"}], :q => {:int => 42, :words => %w[a an the]}}, foo.to_hash)
   end
 
   def test_to_struct_aref


### PR DESCRIPTION
As the modified test shows, a list<string> would not work because
String#to_hash doesn't exist. Solution: don't call String#to_hash
