### PR TITLE
work for i32s in structs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 scratch
 pkg/
 doc/
+*.gem

--- a/lib/stark/protocol_helpers.rb
+++ b/lib/stark/protocol_helpers.rb
@@ -151,7 +151,11 @@ module Stark
         if Hash === additional # Enum hash
           return val.to_sym if val.respond_to?(:to_sym)
         end
-        return additional[val.to_i] if val.respond_to?(:to_i)
+        if additional
+          return additional[val.to_i] if val.respond_to?(:to_i)
+        else
+          return val.to_i
+        end
       when ::Thrift::Types::DOUBLE
         return val.to_f if val.respond_to?(:to_f)
       end

--- a/stark.gemspec
+++ b/stark.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name = "stark"
-  s.version = "0.9.2"
+  s.version = "0.9.3"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Evan Phoenix"]


### PR DESCRIPTION
Just serializing a struct using i32s was failing, it appears because they were closely coupled with enums. This maintains that behavior (the enum coupling), but if it's not in an enum, works the same as i16/i64s.
